### PR TITLE
update to 5.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /usr/src/perl
 
 ## from perl; `true make test_harness` because 3 tests fail
 ## some flags from http://git.alpinelinux.org/cgit/aports/tree/main/perl/APKBUILD?id=19b23f225d6e4f25330e13144c7bf6c01e624656
-RUN curl -SLO https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.2.tar.bz2 \
-    && echo '2057b65e3a6ac71287c973402cd01084a1edc35b *perl-5.26.2.tar.bz2' | sha1sum -c - \
-    && tar --strip-components=1 -xjf perl-5.26.2.tar.bz2 -C /usr/src/perl \
-    && rm perl-5.26.2.tar.bz2 \
+RUN curl -SLO https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.3.tar.bz2 \
+    && echo '4c61872bab631427cbb5b519ef8809d3a4c7f921 *perl-5.26.3.tar.bz2' | sha1sum -c - \
+    && tar --strip-components=1 -xjf perl-5.26.3.tar.bz2 -C /usr/src/perl \
+    && rm perl-5.26.3.tar.bz2 \
     && ./Configure -des \
         -Duse64bitall \
         -Dcccdlflags='-fPIC' \

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Perl on Alpine Linux
 
-This is a build of Perl 5.26.2 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
+This is a build of Perl 5.26.3 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
 
-This Docker image is 219 MB.
+This Docker image is 238 MB.
 
 ## CAVEAT
 
@@ -19,7 +19,7 @@ This Docker image is 219 MB.
       Failed test:  450
     ../lib/warnings.t
       Failed test:  723
-    Files=2553, Tests=1185098, 1286 wallclock secs (94.22 usr 10.28 sys + 774.59 cusr 38.68 csys = 917.77 CPU)
+    Files=2557, Tests=1241510, 293 wallclock secs (99.44 usr 10.83 sys + 784.29 cusr 40.95 csys = 935.51 CPU)
     Result: FAIL
 
 If you depend on the functionality covered by these tests, you may


### PR DESCRIPTION
Fixes CVE-2018-18311, CVE-2018-18312, CVE-2018-18313, CVE-2018-18314.

Also `cpanm CPAN::DistinfoName` (without `--no-verify`) works if you build from Alpine 3.9, which more importantly also means `cpanm Carton` works.

Aside: Does the perl built in this image have any benefits over [Alpine's perl package](https://github.com/alpinelinux/aports/blob/master/main/perl/APKBUILD) nowadays? The resulting image may even be a bit smaller by just using their package.