### PR TITLE
update to 5.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /usr/src/perl
 
 ## from perl; `true make test_harness` because 3 tests fail
 ## some flags from http://git.alpinelinux.org/cgit/aports/tree/main/perl/APKBUILD?id=19b23f225d6e4f25330e13144c7bf6c01e624656
-RUN curl -SLO https://www.cpan.org/src/5.0/perl-5.26.3.tar.gz \
-    && echo '940e1739dd979a284f343dff57ddcbf7f555b928 *perl-5.26.3.tar.gz' | sha1sum -c - \
-    && tar --strip-components=1 -xzf perl-5.26.3.tar.gz -C /usr/src/perl \
-    && rm perl-5.26.3.tar.gz \
+RUN curl -SLO https://www.cpan.org/src/5.0/perl-5.30.0.tar.gz \
+    && echo 'aa5620fb5a4ca125257ae3f8a7e5d05269388856 *perl-5.30.0.tar.gz' | sha1sum -c - \
+    && tar --strip-components=1 -xzf perl-5.30.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.30.0.tar.gz \
     && ./Configure -des \
         -Duse64bitall \
         -Dcccdlflags='-fPIC' \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-build: TAG=5.26
+build: TAG=5.30
 build:
 	docker build -t scottw/alpine-perl:$(TAG) .

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Perl on Alpine Linux
 
-This is a build of Perl 5.26.3 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
+This is a build of Perl 5.30.0 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
 
-This Docker image is 238 MB.
+This Docker image is 246 MB.
 
-NOTE: Recent versions of Alpine include Perl 5.26.3. If you want to use this, use tag `scottw/alpine-perl:5.26-native`.
+NOTE: Recent versions of Alpine include Perl 5.30.0. If you want to use this, use tag `scottw/alpine-perl:5.26-native`.
 
 ## CAVEAT
 
@@ -15,15 +15,33 @@ NOTE: Recent versions of Alpine include Perl 5.26.3. If you want to use this, us
 ```
 Test Summary Report
 -------------------
-../cpan/Time-Piece/t/02core_dst.t                                (Wstat: 768 Tests: 60 Failed: 3)
-  Failed tests:  58-60
-  Non-zero exit status: 3
-../lib/locale.t                                                  (Wstat: 0 Tests: 682 Failed: 1)
-  Failed test:  450
-../lib/warnings.t                                                (Wstat: 0 Tests: 919 Failed: 1)
-  Failed test:  723
-Files=2557, Tests=1241458, 1161 wallclock secs (85.45 usr  9.85 sys + 688.62 cusr 30.45 csys = 814.37 CPU)
-Result: FAIL
+
+t/op/magic ..................................................... ps: unrecognized option: p
+BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.
+
+Usage: ps [-o COL1,COL2=HEADER]
+
+Show list of processes
+
+	-o COL1,COL2=HEADER	Select columns for display
+FAILED--unexpected output at test 102
+
+
+dist/Time-HiRes/t/usleep ....................................... #   Failed test at t/usleep.t line 35.
+# Looks like you failed 1 test of 6.
+FAILED at test 3
+
+cpan/Time-Piece/t/02core_dst ................................... #   Failed test at t/02core_dst.t line 133.
+#          got: '-14400'
+#     expected: '-18000'
+#   Failed test at t/02core_dst.t line 134.
+#          got: '2013-01-09 08:07:11 EDT'
+#     expected: '2013-01-09 07:07:11 EST'
+#   Failed test at t/02core_dst.t line 135.
+#                   '-0400'
+#     doesn't match '(?^:-0500|EST)'
+# Looks like you failed 3 tests of 56.
+FAILED at test 53
 ```
 
 If you depend on the functionality covered by these tests, you may wish to choose another image.


### PR DESCRIPTION
Kindly consider this pull request to provide Perl 5.30.0 for Alpine.

I changed the tarball to download, added the correct hash and updated the Makefile and the README. There are still three tests that don't pass.

Thanks!

Alexander