### PR TITLE
Upgrade to Perl 5.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /usr/src/perl
 
 ## from perl; `true make test_harness` because 3 tests fail
 ## some flags from http://git.alpinelinux.org/cgit/aports/tree/main/perl/APKBUILD?id=19b23f225d6e4f25330e13144c7bf6c01e624656
-RUN curl -SLO https://www.cpan.org/src/5.0/perl-5.30.0.tar.gz \
-    && echo 'aa5620fb5a4ca125257ae3f8a7e5d05269388856 *perl-5.30.0.tar.gz' | sha1sum -c - \
-    && tar --strip-components=1 -xzf perl-5.30.0.tar.gz -C /usr/src/perl \
-    && rm perl-5.30.0.tar.gz \
+RUN curl -SLO https://www.cpan.org/src/5.0/perl-5.32.0.tar.gz \
+    && echo 'ddecb3117c016418b19ed3a8827e4b521b47d6bb *perl-5.32.0.tar.gz' | sha1sum -c - \
+    && tar --strip-components=1 -xzf perl-5.32.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.32.0.tar.gz \
     && ./Configure -des \
         -Duse64bitall \
         -Dcccdlflags='-fPIC' \
@@ -27,7 +27,7 @@ RUN curl -SLO https://www.cpan.org/src/5.0/perl-5.30.0.tar.gz \
         -Dusenm \
     && make libperl.so \
     && make -j$(nproc) \
-    && true TEST_JOBS=$(nproc) make test_harness \
+    && TEST_JOBS=$(nproc) make test_harness \
     && make install \
     && curl -LO https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm \
     && chmod +x cpanm \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-build: TAG=5.30
+build: TAG=5.32
 build:
 	docker build -t scottw/alpine-perl:$(TAG) .

--- a/README.md
+++ b/README.md
@@ -2,46 +2,8 @@
 
 Perl on Alpine Linux
 
-This is a build of Perl 5.30.0 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
+This is a build of Perl 5.32.0 on Alpine Linux. Because of its small size and pre-installed `cpanm`, this is an ideal base for Perl-based Docker images.
 
-This Docker image is 246 MB.
+This Docker image is 292 MB.
 
-NOTE: Recent versions of Alpine include Perl 5.30.0. If you want to use this, use tag `scottw/alpine-perl:5.26-native`.
-
-## CAVEAT
-
-3 tests in Perl's suite fail:
-
-```
-Test Summary Report
--------------------
-
-t/op/magic ..................................................... ps: unrecognized option: p
-BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.
-
-Usage: ps [-o COL1,COL2=HEADER]
-
-Show list of processes
-
-	-o COL1,COL2=HEADER	Select columns for display
-FAILED--unexpected output at test 102
-
-
-dist/Time-HiRes/t/usleep ....................................... #   Failed test at t/usleep.t line 35.
-# Looks like you failed 1 test of 6.
-FAILED at test 3
-
-cpan/Time-Piece/t/02core_dst ................................... #   Failed test at t/02core_dst.t line 133.
-#          got: '-14400'
-#     expected: '-18000'
-#   Failed test at t/02core_dst.t line 134.
-#          got: '2013-01-09 08:07:11 EDT'
-#     expected: '2013-01-09 07:07:11 EST'
-#   Failed test at t/02core_dst.t line 135.
-#                   '-0400'
-#     doesn't match '(?^:-0500|EST)'
-# Looks like you failed 3 tests of 56.
-FAILED at test 53
-```
-
-If you depend on the functionality covered by these tests, you may wish to choose another image.
+NOTE: Recent versions of Alpine include Perl 5.30.0. 


### PR DESCRIPTION
Scott,

kindly consider the changes that I made to upgrade Perl to 5.32.0.

It seems that the compile errors from earlier versions have been fixed now. Thus, I removed the entries from the README.

Thanks!

   Alexander

* Updated versions and hash
* Updated README
* Tests seem to run now -> removed 'true' in Dokerfile
* Removed notice for failing tests in README